### PR TITLE
Change led blink

### DIFF
--- a/attiny/attiny.ino
+++ b/attiny/attiny.ino
@@ -18,6 +18,8 @@
 #include <avr/wdt.h>
 #include <avr/sleep.h>
 
+#define VERSION 4
+
 #define I2C_SLAVE_ADDRESS 0x04 // Address of the slave
 #define POWER_LED 1
 #define PI_POWER_PIN 3
@@ -51,15 +53,17 @@ enum State {
   PI_WDT_FAILED             // WDT for RPi failed. Turn off and on.
 };
 
-#define I2C_READ_REG_LEN 2
+#define I2C_READ_REG_LEN 3
 #define I2C_READ_BATTERY_VOLTAGE_LO 0x20
 #define I2C_READ_BATTERY_VOLTAGE_HI 0x21
+#define I2C_READ_VERSION 0x22
 
 volatile byte i2cReadRegVal = 0x00;
 volatile byte i2cReadRegs[I2C_READ_REG_LEN] =
 {
     I2C_READ_BATTERY_VOLTAGE_LO,
-    I2C_READ_BATTERY_VOLTAGE_HI
+    I2C_READ_BATTERY_VOLTAGE_HI,
+    I2C_READ_VERSION
 };
 
 State state = PI_POWERED;
@@ -206,6 +210,9 @@ void requestEvent() {
       break;
     case I2C_READ_BATTERY_VOLTAGE_HI:
       TinyWireS.send(batteryVoltageI2c >> 8);
+      break;
+    case I2C_READ_VERSION:
+      TinyWireS.send(VERSION);
       break;
   }
   i2cReadRegVal = 0x00;

--- a/attiny/attiny.ino
+++ b/attiny/attiny.ino
@@ -42,8 +42,8 @@ volatile uint16_t piSleepTime = 0; // Counting down the time until the pi will b
 volatile uint8_t minuteCountdown = MINUTE_COUNTDOWN;
 unsigned int piWDTCountdown = PI_WDT_RESET_VAL;
 volatile bool wdt_interrupt_f = false;
-volatile byte onWiFi = 0x00;
-volatile bool gotWDT = false;
+volatile bool onWiFi = false;
+volatile bool gotWDPing = false;
 
 uint16_t batteryVoltageI2c;  // Battery voltage reading for I2c
 
@@ -250,7 +250,7 @@ void receiveEvent(uint8_t howMany) {
       if (howMany != 1) {
         break;
       }
-      gotWDT = true;
+      gotWDPing = true;
       setBlinks(1);
       piWDTCountdown = PI_WDT_RESET_VAL;
       successfulRead = true;
@@ -259,7 +259,7 @@ void receiveEvent(uint8_t howMany) {
       if (howMany != 2) {
         break;
       }
-      onWiFi = TinyWireS.receive();
+      onWiFi = TinyWireS.receive() == 0x01;
       successfulRead = true;
       break;
      default:
@@ -318,10 +318,10 @@ void update_power_led() {
       powerLedIntensity--;
       analogWrite(POWER_LED, powerLedIntensity);
       if (powerLedIntensity <= 1) {
-        if (!gotWDT) {
+        if (!gotWDPing) {
           blinks = 2;
         }
-        else if (onWiFi != 0x01) {
+        else if (!onWiFi) {
           blinks = 1;
         }
         if (blinks >= 1) {


### PR DESCRIPTION
The ATtiny LED will now blink x amount of times after each pulse.
The blinks indicate the state of the RPi.
They are as follow:
2 blinks: ATtiny has not yet received a WDT from the Raspbery Pi.
1 blink: ATtiny has received a WDT but the raspberry Pi has not connected to a wifi network.
No blinks: The Raspberry Pi has connected to a wifi network.
attiny-controller will have to be updated to send the state of the wifi before this will properly work.
Also added a version to the ATtiny firmware. Starting at version number 4 as the earlier version would send 3 to all I2C read requests.
